### PR TITLE
Add a cache for resource headers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,12 @@
       <groupId>edu.wisc.library.ocfl</groupId>
       <artifactId>ocfl-java-core</artifactId>
       <version>0.0.5-SNAPSHOT</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.github.ben-manes.caffeine</groupId>
+          <artifactId>caffeine</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -89,6 +95,12 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>1.7.30</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+      <version>2.8.5</version>
     </dependency>
 
     <!-- Test -->

--- a/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionFactory.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionFactory.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import edu.wisc.library.ocfl.api.MutableOcflRepository;
+import org.fcrepo.storage.ocfl.cache.Cache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,6 +47,7 @@ public class DefaultOcflObjectSessionFactory implements OcflObjectSessionFactory
     private final Path stagingRoot;
     private final ObjectReader headerReader;
     private final ObjectWriter headerWriter;
+    private final Cache<String, ResourceHeaders> headersCache;
     private CommitType defaultCommitType;
     private final String defaultVersionMessage;
     private final String defaultVersionUserName;
@@ -58,6 +60,7 @@ public class DefaultOcflObjectSessionFactory implements OcflObjectSessionFactory
     public DefaultOcflObjectSessionFactory(final MutableOcflRepository ocflRepo,
                                            final Path stagingRoot,
                                            final ObjectMapper objectMapper,
+                                           final Cache<String, ResourceHeaders> headersCache,
                                            final CommitType defaultCommitType,
                                            final String defaultVersionMessage,
                                            final String defaultVersionUserName,
@@ -67,6 +70,7 @@ public class DefaultOcflObjectSessionFactory implements OcflObjectSessionFactory
         this.headerReader = Objects.requireNonNull(objectMapper, "objectMapper cannot be null")
                 .readerFor(ResourceHeaders.class);
         this.headerWriter = objectMapper.writerFor(ResourceHeaders.class);
+        this.headersCache = headersCache;
         this.defaultCommitType = Objects.requireNonNull(defaultCommitType, "defaultCommitType cannot be null");
         this.defaultVersionMessage = defaultVersionMessage;
         this.defaultVersionUserName = defaultVersionUserName;
@@ -87,6 +91,7 @@ public class DefaultOcflObjectSessionFactory implements OcflObjectSessionFactory
                 headerReader,
                 headerWriter,
                 defaultCommitType,
+                headersCache,
                 () -> sessions.remove(sessionId)
         );
 

--- a/src/main/java/org/fcrepo/storage/ocfl/OcflObjectSession.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/OcflObjectSession.java
@@ -46,9 +46,10 @@ public interface OcflObjectSession extends AutoCloseable {
      *
      * @param headers the resource's headers
      * @param content the resource's content, may be null if the resource has no content
+     * @return the resource headers that were written to disk, these may differ from the input headers
      * @throws InvalidContentException when the content size in the headers does not match the actual content size
      */
-    void writeResource(final ResourceHeaders headers, final InputStream content);
+    ResourceHeaders writeResource(final ResourceHeaders headers, final InputStream content);
 
     /**
      * Deletes a content file from the session, and updates the associated headers. If the resource was added in

--- a/src/main/java/org/fcrepo/storage/ocfl/ResourceHeaders.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/ResourceHeaders.java
@@ -18,11 +18,17 @@
 
 package org.fcrepo.storage.ocfl;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
 import java.net.URI;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Resource headers contain metadata about Fedora resources in Fedora 6.
@@ -32,29 +38,104 @@ import java.util.Objects;
  * @author bbpennel
  * @author pwinckles
  */
+@JsonDeserialize(builder = ResourceHeaders.Builder.class)
 public class ResourceHeaders {
 
-    private String id;
-    private String parent;
-    private String stateToken;
-    private String interactionModel;
-    private String mimeType;
-    private String filename;
-    private Long contentSize;
-    private Collection<URI> digests;
-    private String externalUrl;
-    private String externalHandling;
-    private Instant createdDate;
-    private String createdBy;
-    private Instant lastModifiedDate;
-    private String lastModifiedBy;
-    private boolean archivalGroup;
-    private boolean objectRoot;
-    private boolean deleted;
-    private String contentPath;
+    private final String id;
+    private final String parent;
+    private final String stateToken;
+    private final String interactionModel;
+    private final String mimeType;
+    private final String filename;
+    private final Long contentSize;
+    private final Collection<URI> digests;
+    private final String externalUrl;
+    private final String externalHandling;
+    private final Instant createdDate;
+    private final String createdBy;
+    private final Instant lastModifiedDate;
+    private final String lastModifiedBy;
+    private final boolean archivalGroup;
+    private final boolean objectRoot;
+    private final boolean deleted;
+    private final String contentPath;
 
-    public ResourceHeaders() {
-        digests = new ArrayList<>();
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static Builder builder(final ResourceHeaders original) {
+        return new Builder(original);
+    }
+
+    private ResourceHeaders(final Builder builder) {
+        this(builder.id,
+                builder.parent,
+                builder.stateToken,
+                builder.interactionModel,
+                builder.mimeType,
+                builder.filename,
+                builder.contentSize,
+                builder.digests,
+                builder.externalUrl,
+                builder.externalHandling,
+                builder.createdDate,
+                builder.createdBy,
+                builder.lastModifiedDate,
+                builder.lastModifiedBy,
+                builder.archivalGroup,
+                builder.objectRoot,
+                builder.deleted,
+                builder.contentPath);
+    }
+
+    private ResourceHeaders(final String id,
+                           final String parent,
+                           final String stateToken,
+                           final String interactionModel,
+                           final String mimeType,
+                           final String filename,
+                           final Long contentSize,
+                           final Collection<URI> digests,
+                           final String externalUrl,
+                           final String externalHandling,
+                           final Instant createdDate,
+                           final String createdBy,
+                           final Instant lastModifiedDate,
+                           final String lastModifiedBy,
+                           final boolean archivalGroup,
+                           final boolean objectRoot,
+                           final boolean deleted,
+                           final String contentPath) {
+        this.id = id;
+        this.parent = parent;
+        this.stateToken = stateToken;
+        this.interactionModel = interactionModel;
+        this.mimeType = mimeType;
+        this.filename = filename;
+        this.contentSize = contentSize;
+        if (digests == null) {
+            this.digests = Collections.emptyList();
+        } else {
+            // This is necessary so that ResourceHeaders.equals() still works as expected in tests
+            if (digests instanceof List) {
+                this.digests = Collections.unmodifiableList((List<URI>) digests);
+            } else if (digests instanceof Set) {
+                this.digests = Collections.unmodifiableSet((Set<URI>) digests);
+            } else {
+                this.digests = Collections.unmodifiableCollection(digests);
+            }
+        }
+        this.externalUrl = externalUrl;
+        this.externalHandling = externalHandling;
+        this.createdDate = createdDate;
+        this.createdBy = createdBy;
+        this.lastModifiedDate = lastModifiedDate;
+        this.lastModifiedBy = lastModifiedBy;
+        this.archivalGroup = archivalGroup;
+        this.objectRoot = objectRoot;
+        this.deleted = deleted;
+        this.contentPath = contentPath;
     }
 
     /**
@@ -65,24 +146,10 @@ public class ResourceHeaders {
     }
 
     /**
-     * @param id the fedora id to set
-     */
-    public void setId(final String id) {
-        this.id = id;
-    }
-
-    /**
      * @return the parent fedora id
      */
     public String getParent() {
         return parent;
-    }
-
-    /**
-     * @param parent the parent to set
-     */
-    public void setParent(final String parent) {
-        this.parent = parent;
     }
 
     /**
@@ -93,24 +160,10 @@ public class ResourceHeaders {
     }
 
     /**
-     * @param stateToken the stateToken to set
-     */
-    public void setStateToken(final String stateToken) {
-        this.stateToken = stateToken;
-    }
-
-    /**
      * @return the interactionModel
      */
     public String getInteractionModel() {
         return interactionModel;
-    }
-
-    /**
-     * @param interactionModel the interactionModel to set
-     */
-    public void setInteractionModel(final String interactionModel) {
-        this.interactionModel = interactionModel;
     }
 
     /**
@@ -121,24 +174,10 @@ public class ResourceHeaders {
     }
 
     /**
-     * @param mimeType the mimeType to set
-     */
-    public void setMimeType(final String mimeType) {
-        this.mimeType = mimeType;
-    }
-
-    /**
      * @return the filename
      */
     public String getFilename() {
         return filename;
-    }
-
-    /**
-     * @param filename the filename to set
-     */
-    public void setFilename(final String filename) {
-        this.filename = filename;
     }
 
     /**
@@ -149,28 +188,10 @@ public class ResourceHeaders {
     }
 
     /**
-     * @param contentSize the contentSize to set
-     */
-    public void setContentSize(final Long contentSize) {
-        this.contentSize = contentSize;
-    }
-
-    /**
      * @return the digests
      */
     public Collection<URI> getDigests() {
         return digests;
-    }
-
-    /**
-     * @param digests the digests to set
-     */
-    public void setDigests(final Collection<URI> digests) {
-        if (digests == null) {
-            this.digests = new ArrayList<>();
-        } else {
-            this.digests = digests;
-        }
     }
 
     /**
@@ -181,24 +202,10 @@ public class ResourceHeaders {
     }
 
     /**
-     * @param externalHandling the externalHandling to set
-     */
-    public void setExternalHandling(final String externalHandling) {
-        this.externalHandling = externalHandling;
-    }
-
-    /**
      * @return the createdDate
      */
     public Instant getCreatedDate() {
         return createdDate;
-    }
-
-    /**
-     * @param createdDate the createdDate to set
-     */
-    public void setCreatedDate(final Instant createdDate) {
-        this.createdDate = createdDate;
     }
 
     /**
@@ -209,24 +216,10 @@ public class ResourceHeaders {
     }
 
     /**
-     * @param createdBy the createdBy to set
-     */
-    public void setCreatedBy(final String createdBy) {
-        this.createdBy = createdBy;
-    }
-
-    /**
      * @return the lastModifiedDate
      */
     public Instant getLastModifiedDate() {
         return lastModifiedDate;
-    }
-
-    /**
-     * @param lastModifiedDate the lastModifiedDate to set
-     */
-    public void setLastModifiedDate(final Instant lastModifiedDate) {
-        this.lastModifiedDate = lastModifiedDate;
     }
 
     /**
@@ -237,20 +230,6 @@ public class ResourceHeaders {
     }
 
     /**
-     * @param lastModifiedby the lastModifiedby to set
-     */
-    public void setLastModifiedBy(final String lastModifiedby) {
-        this.lastModifiedBy = lastModifiedby;
-    }
-
-    /**
-     * @param externalUrl the externalUrl to set
-     */
-    public void setExternalUrl(final String externalUrl) {
-        this.externalUrl = externalUrl;
-    }
-
-    /**
      * @return the externalUrl
      */
     public String getExternalUrl() {
@@ -258,25 +237,10 @@ public class ResourceHeaders {
     }
 
     /**
-     *
-     * @param flag boolean flag
-     */
-    public void setArchivalGroup(final boolean flag) {
-        this.archivalGroup = flag;
-    }
-
-    /**
      * @return if it is an archival group
      */
     public boolean isArchivalGroup() {
         return archivalGroup;
-    }
-
-    /**
-     * @param flag boolean flag
-     */
-    public void setObjectRoot(final boolean flag) {
-        this.objectRoot = flag;
     }
 
     /**
@@ -291,14 +255,6 @@ public class ResourceHeaders {
     }
 
     /**
-     * Set deleted status flag.
-     * @param deleted true if deleted (a tombstone).
-     */
-    public void setDeleted(final boolean deleted) {
-        this.deleted = deleted;
-    }
-
-    /**
      * @return if the resource is deleted
      */
     public boolean isDeleted() {
@@ -310,13 +266,6 @@ public class ResourceHeaders {
      */
     public String getContentPath() {
         return contentPath;
-    }
-
-    /**
-     * @param contentPath the path to the associated content file
-     */
-    public void setContentPath(final String contentPath) {
-        this.contentPath = contentPath;
     }
 
     @Override
@@ -380,6 +329,159 @@ public class ResourceHeaders {
                 externalHandling, createdDate, createdBy,
                 lastModifiedDate, lastModifiedBy, archivalGroup,
                 objectRoot, deleted, contentPath);
+    }
+
+    /**
+     * Builder for creating/mutating ResourceHeaders
+     */
+    @JsonPOJOBuilder
+    public static class Builder {
+
+        private String id;
+        private String parent;
+        private String stateToken;
+        private String interactionModel;
+        private String mimeType;
+        private String filename;
+        private Long contentSize;
+        private Collection<URI> digests;
+        private String externalUrl;
+        private String externalHandling;
+        private Instant createdDate;
+        private String createdBy;
+        private Instant lastModifiedDate;
+        private String lastModifiedBy;
+        private boolean archivalGroup;
+        private boolean objectRoot;
+        private boolean deleted;
+        private String contentPath;
+
+        public Builder() {
+
+        }
+
+        public Builder(final ResourceHeaders original) {
+            this.id = original.getId();
+            this.parent = original.getParent();
+            this.stateToken = original.getStateToken();
+            this.interactionModel = original.getInteractionModel();
+            this.mimeType = original.getMimeType();
+            this.filename = original.getFilename();
+            this.contentSize = original.getContentSize();
+            this.digests = new ArrayList<>(original.getDigests());
+            this.externalUrl = original.getExternalUrl();
+            this.externalHandling = original.getExternalHandling();
+            this.createdDate = original.getCreatedDate();
+            this.createdBy = original.getCreatedBy();
+            this.lastModifiedDate = original.getLastModifiedDate();
+            this.lastModifiedBy = original.getLastModifiedBy();
+            this.archivalGroup = original.isArchivalGroup();
+            this.objectRoot = original.isObjectRoot();
+            this.deleted = original.isDeleted();
+            this.contentPath = original.getContentPath();
+        }
+
+        public Builder withId(final String id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder withParent(final String parent) {
+            this.parent = parent;
+            return this;
+        }
+
+        public Builder withStateToken(final String stateToken) {
+            this.stateToken = stateToken;
+            return this;
+        }
+
+        public Builder withInteractionModel(final String interactionModel) {
+            this.interactionModel = interactionModel;
+            return this;
+        }
+
+        public Builder withMimeType(final String mimeType) {
+            this.mimeType = mimeType;
+            return this;
+        }
+
+        public Builder withFilename(final String filename) {
+            this.filename = filename;
+            return this;
+        }
+
+        public Builder withContentSize(final Long contentSize) {
+            this.contentSize = contentSize;
+            return this;
+        }
+
+        public Builder withDigests(final Collection<URI> digests) {
+            this.digests = digests;
+            return this;
+        }
+
+        public Builder addDigest(final URI digest) {
+            if (digests == null) {
+                digests = new ArrayList<>();
+            }
+            digests.add(digest);
+            return this;
+        }
+
+        public Builder withExternalUrl(final String externalUrl) {
+            this.externalUrl = externalUrl;
+            return this;
+        }
+
+        public Builder withExternalHandling(final String externalHandling) {
+            this.externalHandling = externalHandling;
+            return this;
+        }
+
+        public Builder withCreatedDate(final Instant createdDate) {
+            this.createdDate = createdDate;
+            return this;
+        }
+
+        public Builder withCreatedBy(final String createdBy) {
+            this.createdBy = createdBy;
+            return this;
+        }
+
+        public Builder withLastModifiedDate(final Instant lastModifiedDate) {
+            this.lastModifiedDate = lastModifiedDate;
+            return this;
+        }
+
+        public Builder withLastModifiedBy(final String lastModifiedBy) {
+            this.lastModifiedBy = lastModifiedBy;
+            return this;
+        }
+
+        public Builder withArchivalGroup(final boolean archivalGroup) {
+            this.archivalGroup = archivalGroup;
+            return this;
+        }
+
+        public Builder withObjectRoot(final boolean objectRoot) {
+            this.objectRoot = objectRoot;
+            return this;
+        }
+
+        public Builder withDeleted(final boolean deleted) {
+            this.deleted = deleted;
+            return this;
+        }
+
+        public Builder withContentPath(final String contentPath) {
+            this.contentPath = contentPath;
+            return this;
+        }
+
+        public ResourceHeaders build() {
+            return new ResourceHeaders(this);
+        }
     }
 
 }

--- a/src/main/java/org/fcrepo/storage/ocfl/cache/Cache.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/cache/Cache.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.storage.ocfl.cache;
+
+import java.util.function.Function;
+
+/**
+ * Cache interface
+ *
+ * @param <K> type of cache key
+ * @param <V> type of cache value
+ *
+ * @author pwinckles
+ */
+public interface Cache<K,V> {
+
+    /**
+     * Retrieves a value from the cache. If it doesn't exist, the loader is called to load the object, which is then
+     * cached and returned.
+     *
+     * @param key to lookup in the cache
+     * @param loader function to call to load the object if it's not found
+     * @return the object that maps to the key
+     */
+    V get(final K key, final Function<K, V> loader);
+
+    /**
+     * Inserts a value into the cache.
+     *
+     * @param key key
+     * @param value value
+     */
+    void put(final K key, final V value);
+
+    /**
+     * Invalidates the key in the cache.
+     *
+     * @param key key
+     */
+    void invalidate(final K key);
+
+}

--- a/src/main/java/org/fcrepo/storage/ocfl/cache/CaffeineCache.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/cache/CaffeineCache.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.storage.ocfl.cache;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * In-memory cache implementation that is a wrapper around a Caffeine cache.
+ *
+ * @author pwinckles
+ */
+public class CaffeineCache<K, V> implements Cache<K, V> {
+
+    private com.github.benmanes.caffeine.cache.Cache<K, V> cache;
+
+    public CaffeineCache(final com.github.benmanes.caffeine.cache.Cache cache) {
+        this.cache = Objects.requireNonNull(cache, "cache cannot be null");
+    }
+
+    @Override
+    public V get(final K key, final Function<K, V> loader) {
+        return cache.get(key, loader);
+    }
+
+    @Override
+    public void put(final K key, final V value) {
+        cache.put(key, value);
+    }
+
+    @Override
+    public void invalidate(final K key) {
+        cache.invalidate(key);
+    }
+
+}

--- a/src/main/java/org/fcrepo/storage/ocfl/cache/NoOpCache.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/cache/NoOpCache.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.storage.ocfl.cache;
+
+import java.util.function.Function;
+
+/**
+ * Pass-through cache implementation that never caches.
+ *
+ * @author pwinckles
+ */
+public class NoOpCache<K, V> implements Cache<K, V> {
+
+    @Override
+    public V get(final K key, final Function<K, V> loader) {
+        return loader.apply(key);
+    }
+
+    @Override
+    public void put(final K key, final V value) {
+        // no op
+    }
+
+    @Override
+    public void invalidate(final K key) {
+        // no op
+    }
+
+}

--- a/src/test/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionFactoryTest.java
+++ b/src/test/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionFactoryTest.java
@@ -27,6 +27,7 @@ import edu.wisc.library.ocfl.core.extension.storage.layout.config.HashedTruncate
 import edu.wisc.library.ocfl.core.path.mapper.LogicalPathMappers;
 import edu.wisc.library.ocfl.core.storage.filesystem.FileSystemOcflStorage;
 import org.apache.commons.lang3.SystemUtils;
+import org.fcrepo.storage.ocfl.cache.NoOpCache;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -80,7 +81,10 @@ public class DefaultOcflObjectSessionFactoryTest {
                 .registerModule(new JavaTimeModule())
                 .setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
-        sessionFactory = new DefaultOcflObjectSessionFactory(ocflRepo, sessionStaging, objectMapper,
+        sessionFactory = new DefaultOcflObjectSessionFactory(ocflRepo,
+                sessionStaging,
+                objectMapper,
+                new NoOpCache<>(),
                 CommitType.NEW_VERSION, DEFAULT_MESSAGE, DEFAULT_USER, DEFAULT_ADDRESS);
     }
 


### PR DESCRIPTION
**Jira**: https://jira.lyrasis.org/browse/FCREPO-3453

## What this does

Adds a resource headers cache to the storage layer. Resource headers are accessed from the cache whenever possible rather than reading them from storage.

## How to test

Easiest to test with Fedora integration. PR: https://github.com/fcrepo/fcrepo/pull/1772