### PR TITLE
upgrade ocfl-java version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>edu.wisc.library.ocfl</groupId>
       <artifactId>ocfl-java-core</artifactId>
-      <version>0.0.5-SNAPSHOT</version>
+      <version>0.0.6-SNAPSHOT</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Upgrade the version of ocfl-java. This will fix the memory leak that was recently discovered.