### PR TITLE
remove session map from session factory

### DIFF
--- a/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSession.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSession.java
@@ -90,7 +90,6 @@ public class DefaultOcflObjectSession implements OcflObjectSession {
     private final ObjectReader headerReader;
     private final ObjectWriter headerWriter;
     private final Cache<String, ResourceHeaders> headersCache;
-    private final Runnable deregisterHook;
 
     private final DigestAlgorithm digestAlgorithm;
     private final OcflOption[] ocflOptions;
@@ -112,8 +111,7 @@ public class DefaultOcflObjectSession implements OcflObjectSession {
                                     final ObjectReader headerReader,
                                     final ObjectWriter headerWriter,
                                     final CommitType commitType,
-                                    final Cache<String, ResourceHeaders> headersCache,
-                                    final Runnable deregisterHook) {
+                                    final Cache<String, ResourceHeaders> headersCache) {
         this.sessionId = Objects.requireNonNull(sessionId, "sessionId cannot be null");
         this.ocflRepo = Objects.requireNonNull(ocflRepo, "ocflRepo cannot be null");
         this.ocflObjectId = Objects.requireNonNull(ocflObjectId, "ocflObjectId cannot be null");
@@ -122,7 +120,6 @@ public class DefaultOcflObjectSession implements OcflObjectSession {
         this.headerWriter = Objects.requireNonNull(headerWriter, "headerWriter cannot be null");
         this.commitType = Objects.requireNonNull(commitType, "commitType cannot be null");
         this.headersCache = Objects.requireNonNull(headersCache, "headersCache cannot be null");
-        this.deregisterHook = Objects.requireNonNull(deregisterHook, "deregisterHook cannot be null");
 
         this.versionInfo = new VersionInfo();
         this.deletePaths = new HashSet<>();
@@ -795,7 +792,6 @@ public class DefaultOcflObjectSession implements OcflObjectSession {
         if (Files.exists(objectStaging)) {
             FileUtils.deleteQuietly(objectStaging.toFile());
         }
-        deregisterHook.run();
     }
 
     private void enforceOpen() {

--- a/src/main/java/org/fcrepo/storage/ocfl/OcflObjectSessionFactory.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/OcflObjectSessionFactory.java
@@ -18,8 +18,6 @@
 
 package org.fcrepo.storage.ocfl;
 
-import java.util.Optional;
-
 /**
  * Factory for creating OcflObjectSessions.
  *
@@ -36,15 +34,7 @@ public interface OcflObjectSessionFactory {
     OcflObjectSession newSession(final String ocflObjectId);
 
     /**
-     * Returns an existing session, if one exists.
-     *
-     * @param sessionId the id of an OcflObjectSession
-     * @return an existing session
-     */
-    Optional<OcflObjectSession> existingSession(final String sessionId);
-
-    /**
-     * Closes the underlying OCFL repository, and aborts all active sessions.
+     * Closes the underlying OCFL repository.
      */
     void close();
 

--- a/src/test/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionFactoryTest.java
+++ b/src/test/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionFactoryTest.java
@@ -37,10 +37,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author pwinckles
@@ -94,37 +91,6 @@ public class DefaultOcflObjectSessionFactoryTest {
         final var session2 = sessionFactory.newSession("obj1");
 
         assertNotEquals(session1.sessionId(), session2.sessionId());
-    }
-
-    @Test
-    public void returnAnExistingOpenSession() {
-        final var session1 = sessionFactory.newSession("obj1");
-        final var session2 = sessionFactory.existingSession(session1.sessionId());
-
-        assertTrue(session2.isPresent());
-        assertEquals(session1.sessionId(), session2.get().sessionId());
-    }
-
-    @Test
-    public void returnNothingWhenThereIsNotAnExistingOpenSession() {
-        final var session1 = sessionFactory.newSession("obj1");
-
-        session1.abort();
-
-        final var session2 = sessionFactory.existingSession(session1.sessionId());
-
-        assertTrue(session2.isEmpty());
-    }
-
-    @Test
-    public void closeFactoryAndAllActiveSessions() {
-        final var session1 = sessionFactory.newSession("obj1");
-        final var session2 = sessionFactory.newSession("obj2");
-
-        sessionFactory.close();
-
-        assertFalse(session1.isOpen());
-        assertFalse(session2.isOpen());
     }
 
 }


### PR DESCRIPTION
This removes the session map from the session factory. It's a feature that is not used anywhere, and is creating a memory leak in fcrepo because the read-only sessions are never closed.